### PR TITLE
Adding reporting in html and and junit reporters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 package-lock.json
 /source/node_modules
+/source/cypress/downloads
+/source/output-generation

--- a/source/cypress.config.js
+++ b/source/cypress.config.js
@@ -4,10 +4,29 @@ module.exports = defineConfig({
   env: {
     loginBase: 'https://www.saucedemo.com'
   },
+  viewportHeight: 1080,
+  viewportWidth: 1920,
+  
   e2e: {
     chromeWebSecurity: false,
     setupNodeEvents(on, config) {
       // implement node event listeners here
     },
+    screenshotsFolder: "output-generation/screenshots",
+    videosFolder: "output-generation/videos"
   },
+  reporter: 'cypress-multi-reporters',
+  reporterOptions: {
+    reporterEnabled: 'mochawesome, mocha-junit-reporter',
+    mochawesomeReporterOptions: {
+      reportDir: 'output-generation/reports/mocha',
+      quite: true,
+      overwrite: false,
+      html: false,
+      json: true
+    },
+    mochaJunitReporterReporterOptions: {
+      mochaFile: 'output-generation/reports/junit/results-[hash].xml'
+    }
+  }
 });

--- a/source/cypress/e2e/inventory.cy.js
+++ b/source/cypress/e2e/inventory.cy.js
@@ -1,0 +1,14 @@
+/// <reference types="cypress" />
+
+import { LoginPage } from '../support/page_object/login-page.po'
+
+describe('Inventory', ()=> {
+    const loginElement = new LoginPage()
+    beforeEach(()=>{
+        cy.login()
+    })
+
+    it('should verify default on the page', () => {
+        loginElement.loginLogo().should('have.text', 'Swag Labs')
+    })
+})

--- a/source/package.json
+++ b/source/package.json
@@ -4,7 +4,9 @@
   "description": "This solution of UI automation contain page object model pattern.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "cy:run": "cypress run --headless --browser chrome",
+    "combine-reports": "mochawesome-merge output-generation/reports/mocha/**.json > output-generation/reports/report.json",
+    "generate-reports": "marge output-generation/reports/report.json -f report -o output-generation/reports/mochareports"
   },
   "repository": {
     "type": "git",
@@ -17,6 +19,11 @@
   },
   "homepage": "https://github.com/automationsangrah/demo-webui-cypress#readme",
   "devDependencies": {
-    "cypress": "^13.6.2"
+    "cypress": "^13.6.2",
+    "cypress-multi-reporters": "^1.6.4",
+    "mocha-junit-reporter": "^2.2.1",
+    "mochawesome": "^7.1.3",
+    "mochawesome-merge": "^4.3.0",
+    "mochawesome-report-generator": "^6.2.0"
   }
 }


### PR DESCRIPTION
cypress-multi-reporters -> for generating reports in multiple formats
mocha-junit-reporter -> for generating reports in JUnit, useful for CI pipelines
mochawesome -> to generate report(s) in HTML format
mochawesome-merge -> will merge all the JSON files into single file(By default mochawesome generates 1 JSON per spec)
mochawesome-report-generator - > will generate an HTML report from 1 JSON

configuration added for generating results.

Script added to run test 'cy:run', merge in single JSON 'combine-reports', and generate an HTML report 'generate-reports'.

Added one test file, which will fail to see pass/fail both the results in HTML.