### PR TITLE
configuring screenshots to html report

### DIFF
--- a/source/cypress/support/e2e.js
+++ b/source/cypress/support/e2e.js
@@ -15,6 +15,13 @@
 
 // Import commands.js using ES2015 syntax:
 import './commands'
-
+import addContext from 'mochawesome/addContext'
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
+
+Cypress.on("test:after:run", (test,runnable) => {
+    if (test.state === 'failed') {
+        const screenshot = `../../../source/output-generation/screenshots/${Cypress.spec.name}/${runnable.parent.title} -- ${test.title} (failed).png`
+        addContext({ test }, screenshot)
+    }
+})

--- a/source/package.json
+++ b/source/package.json
@@ -4,9 +4,9 @@
   "description": "This solution of UI automation contain page object model pattern.",
   "main": "index.js",
   "scripts": {
-    "cy:run": "cypress run --headless --browser chrome",
+    "cy:run": "cypress run --headless --browser chrome --spec ./cypress/e2e/*.cy.js",
     "combine-reports": "mochawesome-merge output-generation/reports/mocha/**.json > output-generation/reports/report.json",
-    "generate-reports": "marge output-generation/reports/report.json -f report -o output-generation/reports/mochareports"
+    "generate-reports": "marge output-generation/reports/report.json -f report -o output-generation/reports"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
added code into e2e.js for registering screenshots to the HTML report.
A screenshot will be added to the HTML report for each failed test case.
updating cy:run the script with the spec path.
